### PR TITLE
fix/459: selector not found error message style

### DIFF
--- a/walkhub.css
+++ b/walkhub.css
@@ -31,6 +31,14 @@
   font-size: 12px;
   cursor: default;
   font-weight: bold;
+  white-space: normal;
+  padding: 5px;
+  line-height: 16px;
+  margin-bottom: 5px;
+}
+
+.button.markbroken {
+  float: right;
 }
 
 #walkhub-record-form .form-item-steps {

--- a/walkhub.js
+++ b/walkhub.js
@@ -370,7 +370,7 @@
           event.preventDefault();
           flagWalkthroughAsBroken();
         })
-        .appendTo(msg);
+        .appendTo(msg.parent());
 
       if (getdata.markbroken) {
         link.click();
@@ -387,8 +387,8 @@
     var msg = $("<div />")
       .attr("id", "walkhub-error-message-" + id)
       .addClass("walkhub-error-message")
-      .html(error)
-      .appendTo($("span.ui-dialog-title", methods.iframe.object.parent()));
+      .html(error);
+    $("span.ui-dialog-title", methods.iframe.object.parent()).html(msg);
 
     if (errormessages_alter.hasOwnProperty(id)) {
       errormessages_alter[id](msg);


### PR DESCRIPTION
This commit modifies some css related to the error message in the header,
and modifies the js, which is inserting the error message in the titlebar of the popup,
to use a slightly different markup for the message.
This commit is related to the commit of the main repository with the same title on branch "fix/459..."
