### PR TITLE
Make Groups optional (via module_exists())

### DIFF
--- a/walkhub.pages.inc
+++ b/walkhub.pages.inc
@@ -136,7 +136,10 @@ function walkhub_create_walkthrough_form_step_2($form, $form_state) {
             $form_state['walkthrough']->body[LANGUAGE_NONE][0]['value'] : NULL,
   );
 
-  $user_groups = og_get_entity_groups('user', $user);
+  $user_groups = array();
+  if (module_exists('og')) {
+    $user_groups = og_get_entity_groups('user', $user);
+  }
   $options = array();
   if (!empty($user_groups['node'])) {
     $group_nodes = node_load_multiple($user_groups['node']);
@@ -196,11 +199,14 @@ function walkhub_create_walkthrough_form_save($form, &$form_state) {
   $form_state['walkthrough']->title = $form_state['values']['title'];
   $form_state['walkthrough']->body[LANGUAGE_NONE][0]['value'] = $form_state['values']['body'];
   $form_state['walkthrough']->field_severity_of_the_change[LANGUAGE_NONE][0]['value'] = $form_state['values']['severity'];
-  // Set the group audience field value.
-  foreach ($form_state['values']['user_groups'] as $group) {
-    $form_state['walkthrough']->og_group_ref[LANGUAGE_NONE][] = array(
-      'target_id' => $group,
-    );
+
+  if (module_exists('og')) {
+    // Set the group audience field value.
+    foreach ($form_state['values']['user_groups'] as $group) {
+      $form_state['walkthrough']->og_group_ref[LANGUAGE_NONE][] = array(
+        'target_id' => $group,
+      );
+    }
   }
 
   // Save the walkthrough.


### PR DESCRIPTION
When using the walkhub module standalone and editing a walkthrough (I was importing from selenium), if you do not have Organic Groups enabled, PHP will be rather upset:

PHP Fatal error:  Call to undefined function og_get_entity_groups() in /var/www/example/sites/all/modules/walkhub/walkhub.pages.inc on line 139, referer: http://example.com/walkthrough/import

This simply wraps calls (and some form_state items) referencing og functions in a if (module_exists('og')) {things}.
