### PR TITLE
Fixes url length issue.

### DIFF
--- a/walkhub.module
+++ b/walkhub.module
@@ -1238,6 +1238,7 @@ function walkhub_record_form($form, &$form_state, $floating_record_button = FALS
   $form['url'] = array(
     '#type' => 'textfield',
     '#title' => t('Starting URL'),
+    '#maxlength' => 2000,
     '#attributes' => array(
       'class' => array('edit-url'),
     ),


### PR DESCRIPTION
See https://trello.com/c/gXofaswf/600-error-message-starting-url-cannot-be-longer-than-128-characters-but-is-currently-151-characters-long
